### PR TITLE
Add artificial delay for the server responses

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -81,25 +81,33 @@ export function makeServer({ environment = 'development' } = {}) {
       this.namespace = 'api';
 
       // PLANETS
-      this.get('/planets', (schema: any) => {
-        const planetsData = schema.planets.all();
-        return {
-          planets: planetsData.models,
-        };
-      });
-
-      this.get('/planets/:id', (schema: any, request) => {
-        const id = request.params.id;
-        const planet = schema.planets.find(id);
-
-        if (planet) {
-          return planet;
-        } else {
+      this.get(
+        '/planets',
+        (schema: any) => {
+          const planetsData = schema.planets.all();
           return {
-            error: 'Planet not found',
+            planets: planetsData.models,
           };
-        }
-      });
+        }, 
+        { timing: 1500 }
+      );
+
+      this.get(
+        '/planets/:id',
+        (schema: any, request) => {
+          const id = request.params.id;
+          const planet = schema.planets.find(id);
+
+          if (planet) {
+            return planet;
+          } else {
+            return {
+              error: 'Planet not found',
+            };
+          }
+        },
+        { timing: 1500 }
+      );
     },
   });
 


### PR DESCRIPTION
The response from our server's endpoints are so fast today that the lack of load state handling doesn't even show up (and its presence doesn't shine as it should).

This is adding some artificial delay just to make it more realistic.


https://github.com/ledn-reviewer/ledn-frontend-challenge-ui/assets/166427516/163b153d-c169-45eb-82b6-f0eea0b0f9be

